### PR TITLE
Fix desc in redshift_cluster_automatic_upgrades

### DIFF
--- a/prowler/providers/aws/services/redshift/redshift_cluster_automatic_upgrades/redshift_cluster_automatic_upgrades.metadata.json
+++ b/prowler/providers/aws/services/redshift/redshift_cluster_automatic_upgrades/redshift_cluster_automatic_upgrades.metadata.json
@@ -1,14 +1,14 @@
 {
   "Provider": "aws",
   "CheckID": "redshift_cluster_automatic_upgrades",
-  "CheckTitle": "Check for Publicly Accessible Redshift Clusters",
+  "CheckTitle": "Check for Redshift Automatic Version Upgrade",
   "CheckType": [],
   "ServiceName": "redshift",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:redshift:region:account-id:cluster:cluster-name",
   "Severity": "high",
   "ResourceType": "AwsRedshiftCluster",
-  "Description": "Check for Publicly Accessible Redshift Clusters",
+  "Description": "Check for Redshift Automatic Version Upgrade",
   "Risk": "Without automatic version upgrade enabled; a critical Redshift Cluster version can become severly out of date",
   "RelatedUrl": "https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html",
   "Remediation": {


### PR DESCRIPTION
redshift_cluster_automatic_upgrades description is "Check for Publicly Accessible Redshift Clusters"

Changed to describe automatic updates

### Context

Please include relevant motivation and context for this PR.


### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
